### PR TITLE
fix: arraytex.nim(38, 81) Error: complex statement requires indentation

### DIFF
--- a/arraytex.nim
+++ b/arraytex.nim
@@ -35,10 +35,11 @@ var even_odd = 0u32
 for layer in 0..<IMG_LAYERS:
     for y in 0..<IMG_HEIGHT:
         for x in 0..<IMG_WIDTH:
-            pixels[layer][y][x] = if (even_odd and 1) == 0: 0xFF000000u32 else: case layer
-                of 0: 0xFF0000FFu32
-                of 1: 0xFF00FF00u32
-                else: 0xFFFF0000u32
+            pixels[layer][y][x] = if (even_odd and 1) == 0: 0xFF000000u32 else:
+                case layer
+                    of 0: 0xFF0000FFu32
+                    of 1: 0xFF00FF00u32
+                    else: 0xFFFF0000u32
             even_odd += 1
         even_odd += 1
 let img = sg.make_image(image_desc(


### PR DESCRIPTION
Just a simple indentation fix to address a compile error.  Thanks!

```sh
$ nim -v
Nim Compiler Version 0.18.0 [MacOSX: amd64]
Copyright (c) 2006-2018 by Andreas Rumpf

git hash: 855956bf617f68ac0be3717329e9e1181e5dc0c6
active boot switches: -d:release

$ nim c arraytex.nim
arraytex.nim(38, 81) Error: complex statement requires indentation
```